### PR TITLE
feat(motion_lib): add configurable CPU offload for motion data tensors

### DIFF
--- a/humanoidverse/config/robot/g1/g1_23dof_lock_wrist.yaml
+++ b/humanoidverse/config/robot/g1/g1_23dof_lock_wrist.yaml
@@ -180,6 +180,7 @@ robot:
     fix_base_link: False # TEST: fix base link to world
 
   motion:
+    cpu_offload: false   # Set true to offload motion data to CPU pinned memory
     motion_lib_type: 'ZTJ'
     motion_file : ???
     asset:

--- a/humanoidverse/utils/motion_lib/motion_lib_robot_ztj.py
+++ b/humanoidverse/utils/motion_lib/motion_lib_robot_ztj.py
@@ -102,7 +102,8 @@ class MotionLibBase():
 
         self.m_cfg = motion_lib_cfg
         self._sim_fps = 1/self.m_cfg.get("step_dt", 1/50)
-        
+        self.cpu_offload = self.m_cfg.get("cpu_offload", False)
+
         self.num_envs = num_envs
         self._device = device
         # self.mesh_parsers = None
@@ -142,16 +143,29 @@ class MotionLibBase():
             self._motion_data_list = np.array(list(data_list.values()))
             self._motion_data_keys = np.array(list(data_list.keys()))
         else:
+            # Save original list for directory mode before converting to array
+            _motion_data_load_list = list(self._motion_data_load)
             self._motion_data_list = np.array(self._motion_data_load)
             self._motion_data_keys = np.array(self._motion_data_load)
-        
+
         self._num_unique_motions = len(self._motion_data_list)
         if self.mode == MotionlibMode.directory:
-            self._motion_data_load = joblib.load(self._motion_data_load[0]) # set self._motion_data_load to a sample of the data 
+            self._motion_data_load = joblib.load(_motion_data_load_list[0]) # set self._motion_data_load to a sample of the data 
         logger.info(f"Loaded {self._num_unique_motions} motions")
-            
-            
-    def load_motions(self, 
+
+    def _store_tensor(self, t: torch.Tensor) -> torch.Tensor:
+        """Store tensor on pinned CPU memory (offload) or device."""
+        if self.cpu_offload:
+            return t.pin_memory()
+        return t.to(self._device)
+
+    def _fetch(self, t: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+        """Index into a stored tensor, moving result to device if offloaded."""
+        if self.cpu_offload:
+            return t[idx.cpu()].to(self._device)
+        return t[idx]
+
+    def load_motions(self,
                      start_idx=0, 
                      max_len=-1, 
                      target_heading = None):
@@ -219,38 +233,38 @@ class MotionLibBase():
         self._motion_fps = torch.tensor(_motion_fps, device=self._device, dtype=torch.float32)
         self._motion_bodies = torch.stack(_motion_bodies).to(self._device).type(torch.float32)
 
-        self._motion_aa = torch.tensor(np.concatenate(_motion_aa), device=self._device, dtype=torch.float32)
+        self._motion_aa = self._store_tensor(torch.from_numpy(np.concatenate(_motion_aa)).float())
 
         self._motion_dt = torch.tensor(_motion_dt, device=self._device, dtype=torch.float32)
         self._motion_num_frames = torch.tensor(_motion_num_frames, device=self._device)
         if self.has_action:
-            self._motion_actions = torch.cat(_motion_actions, dim=0).float().to(self._device)
+            self._motion_actions = self._store_tensor(torch.cat(_motion_actions, dim=0).float())
         if self.has_contact_mask:
-            self._motion_contact_masks = torch.tensor(np.concatenate(_motion_contact_masks), device=self._device, dtype=torch.float32)
+            self._motion_contact_masks = self._store_tensor(torch.from_numpy(np.concatenate(_motion_contact_masks)).float())
         self._num_motions = len(motions)
-    
-        self.gts = torch.cat([m.global_translation for m in motions], dim=0).float().to(self._device)
-        self.grs = torch.cat([m.global_rotation for m in motions], dim=0).float().to(self._device)
-        self.lrs = torch.cat([m.local_rotation for m in motions], dim=0).float().to(self._device)
-        self.grvs = torch.cat([m.global_root_velocity for m in motions], dim=0).float().to(self._device)
-        self.gravs = torch.cat([m.global_root_angular_velocity for m in motions], dim=0).float().to(self._device)
-        self.gavs = torch.cat([m.global_angular_velocity for m in motions], dim=0).float().to(self._device)
-        self.gvs = torch.cat([m.global_velocity for m in motions], dim=0).float().to(self._device)
-        self.dvs = torch.cat([m.dof_vels for m in motions], dim=0).float().to(self._device)
-        
+
+        self.gts = self._store_tensor(torch.cat([m.global_translation for m in motions], dim=0).float())
+        self.grs = self._store_tensor(torch.cat([m.global_rotation for m in motions], dim=0).float())
+        self.lrs = self._store_tensor(torch.cat([m.local_rotation for m in motions], dim=0).float())
+        self.grvs = self._store_tensor(torch.cat([m.global_root_velocity for m in motions], dim=0).float())
+        self.gravs = self._store_tensor(torch.cat([m.global_root_angular_velocity for m in motions], dim=0).float())
+        self.gavs = self._store_tensor(torch.cat([m.global_angular_velocity for m in motions], dim=0).float())
+        self.gvs = self._store_tensor(torch.cat([m.global_velocity for m in motions], dim=0).float())
+        self.dvs = self._store_tensor(torch.cat([m.dof_vels for m in motions], dim=0).float())
+
         if "global_translation_extend" in motions[0].__dict__:
-            self.gts_t = torch.cat([m.global_translation_extend for m in motions], dim=0).float().to(self._device)
-            self.grs_t = torch.cat([m.global_rotation_extend for m in motions], dim=0).float().to(self._device)
-            self.gvs_t = torch.cat([m.global_velocity_extend for m in motions], dim=0).float().to(self._device)
-            self.gavs_t = torch.cat([m.global_angular_velocity_extend for m in motions], dim=0).float().to(self._device)
-        
+            self.gts_t = self._store_tensor(torch.cat([m.global_translation_extend for m in motions], dim=0).float())
+            self.grs_t = self._store_tensor(torch.cat([m.global_rotation_extend for m in motions], dim=0).float())
+            self.gvs_t = self._store_tensor(torch.cat([m.global_velocity_extend for m in motions], dim=0).float())
+            self.gavs_t = self._store_tensor(torch.cat([m.global_angular_velocity_extend for m in motions], dim=0).float())
+
         if "dof_pos" in motions[0].__dict__:
-            self.dof_pos = torch.cat([m.dof_pos for m in motions], dim=0).float().to(self._device)
+            self.dof_pos = self._store_tensor(torch.cat([m.dof_pos for m in motions], dim=0).float())
         if flags.real_traj:
-            self.q_gts = torch.cat(self.q_gts, dim=0).float().to(self._device)
-            self.q_grs = torch.cat(self.q_grs, dim=0).float().to(self._device)
-            self.q_gavs = torch.cat(self.q_gavs, dim=0).float().to(self._device)
-            self.q_gvs = torch.cat(self.q_gvs, dim=0).float().to(self._device)
+            self.q_gts = self._store_tensor(torch.cat(self.q_gts, dim=0).float())
+            self.q_grs = self._store_tensor(torch.cat(self.q_grs, dim=0).float())
+            self.q_gavs = self._store_tensor(torch.cat(self.q_gavs, dim=0).float())
+            self.q_gvs = self._store_tensor(torch.cat(self.q_gvs, dim=0).float())
         
         lengths = self._motion_num_frames
         lengths_shifted = lengths.roll(1)
@@ -374,8 +388,6 @@ class MotionLibBase():
         return action
 
     def get_motion_state(self, motion_ids, motion_times, offset=None):
-        # import time;print("Called get_motion_state at", time.time())
-
         motion_len = self._motion_lengths[motion_ids]
         num_frames = self._motion_num_frames[motion_ids]
         dt = self._motion_dt[motion_ids]
@@ -384,25 +396,26 @@ class MotionLibBase():
         f0l = frame_idx0 + self.length_starts[motion_ids]
         f1l = frame_idx1 + self.length_starts[motion_ids]
 
+        _d = self._device
+
         if "dof_pos" in self.__dict__:
-            local_rot0 = self.dof_pos[f0l]
-            local_rot1 = self.dof_pos[f1l]
+            local_rot0 = self._fetch(self.dof_pos, f0l)
+            local_rot1 = self._fetch(self.dof_pos, f1l)
         else:
-            local_rot0 = self.lrs[f0l]
-            local_rot1 = self.lrs[f1l]
-            
-        body_vel0 = self.gvs[f0l]
-        body_vel1 = self.gvs[f1l]
+            local_rot0 = self._fetch(self.lrs, f0l)
+            local_rot1 = self._fetch(self.lrs, f1l)
 
-        body_ang_vel0 = self.gavs[f0l]
-        body_ang_vel1 = self.gavs[f1l]
+        body_vel0 = self._fetch(self.gvs, f0l)
+        body_vel1 = self._fetch(self.gvs, f1l)
 
-        # breakpoint()
-        rg_pos0 = self.gts[f0l, :]
-        rg_pos1 = self.gts[f1l, :]
+        body_ang_vel0 = self._fetch(self.gavs, f0l)
+        body_ang_vel1 = self._fetch(self.gavs, f1l)
 
-        dof_vel0 = self.dvs[f0l]
-        dof_vel1 = self.dvs[f1l]
+        rg_pos0 = self._fetch(self.gts, f0l)
+        rg_pos1 = self._fetch(self.gts, f1l)
+
+        dof_vel0 = self._fetch(self.dvs, f0l)
+        dof_vel1 = self._fetch(self.dvs, f1l)
 
         vals = [local_rot0, local_rot1, body_vel0, body_vel1, body_ang_vel0, body_ang_vel1, rg_pos0, rg_pos1, dof_vel0, dof_vel1]
         for v in vals:
@@ -433,23 +446,23 @@ class MotionLibBase():
                 local_rot = slerp(local_rot0, local_rot1, torch.unsqueeze(blend, axis=-1))
             dof_pos = _local_rotation_to_dof_smpl(local_rot)
 
-        rb_rot0 = self.grs[f0l]
-        rb_rot1 = self.grs[f1l]
+        rb_rot0 = self._fetch(self.grs, f0l)
+        rb_rot1 = self._fetch(self.grs, f1l)
         rb_rot = rb_rot0 if skip_blend else slerp(rb_rot0, rb_rot1, blend_exp)
         return_dict = {}
         
         if "gts_t" in self.__dict__:
-            rg_pos_t0 = self.gts_t[f0l]
-            rg_pos_t1 = self.gts_t[f1l]
-            
-            rg_rot_t0 = self.grs_t[f0l]
-            rg_rot_t1 = self.grs_t[f1l]
-            
-            body_vel_t0 = self.gvs_t[f0l]
-            body_vel_t1 = self.gvs_t[f1l]
-            
-            body_ang_vel_t0 = self.gavs_t[f0l]
-            body_ang_vel_t1 = self.gavs_t[f1l]
+            rg_pos_t0 = self._fetch(self.gts_t, f0l)
+            rg_pos_t1 = self._fetch(self.gts_t, f1l)
+
+            rg_rot_t0 = self._fetch(self.grs_t, f0l)
+            rg_rot_t1 = self._fetch(self.grs_t, f1l)
+
+            body_vel_t0 = self._fetch(self.gvs_t, f0l)
+            body_vel_t1 = self._fetch(self.gvs_t, f1l)
+
+            body_ang_vel_t0 = self._fetch(self.gavs_t, f0l)
+            body_ang_vel_t1 = self._fetch(self.gavs_t, f1l)
             if offset is None:
                 rg_pos_t = _lerp(rg_pos_t0, rg_pos_t1, blend_exp)
             else:
@@ -464,10 +477,10 @@ class MotionLibBase():
             body_ang_vel_t = body_ang_vel
         
         if flags.real_traj:
-            q_body_ang_vel0, q_body_ang_vel1 = self.q_gavs[f0l], self.q_gavs[f1l]
-            q_rb_rot0, q_rb_rot1 = self.q_grs[f0l], self.q_grs[f1l]
-            q_rg_pos0, q_rg_pos1 = self.q_gts[f0l, :], self.q_gts[f1l, :]
-            q_body_vel0, q_body_vel1 = self.q_gvs[f0l], self.q_gvs[f1l]
+            q_body_ang_vel0, q_body_ang_vel1 = self._fetch(self.q_gavs, f0l), self._fetch(self.q_gavs, f1l)
+            q_rb_rot0, q_rb_rot1 = self._fetch(self.q_grs, f0l), self._fetch(self.q_grs, f1l)
+            q_rg_pos0, q_rg_pos1 = self._fetch(self.q_gts, f0l), self._fetch(self.q_gts, f1l)
+            q_body_vel0, q_body_vel1 = self._fetch(self.q_gvs, f0l), self._fetch(self.q_gvs, f1l)
 
             q_ang_vel = _lerp(q_body_ang_vel0, q_body_ang_vel1, blend_exp)
             q_rb_rot = q_rb_rot0 if skip_blend else slerp(q_rb_rot0, q_rb_rot1, blend_exp)
@@ -481,7 +494,7 @@ class MotionLibBase():
 
 
         if self.has_contact_mask:
-            contact0, contact1 = self._motion_contact_masks[f0l], self._motion_contact_masks[f1l]
+            contact0, contact1 = self._fetch(self._motion_contact_masks, f0l), self._fetch(self._motion_contact_masks, f1l)
             contact = _lerp(contact0, contact1, blend)
             
             return_dict["contact_mask"] = contact
@@ -494,7 +507,7 @@ class MotionLibBase():
             "root_vel": body_vel[..., 0, :].clone(),
             "root_ang_vel": body_ang_vel[..., 0, :].clone(),
             "dof_vel": dof_vel.view(dof_vel.shape[0], -1),
-            "motion_aa": self._motion_aa[f0l],
+            "motion_aa": self._fetch(self._motion_aa, f0l),
             "motion_bodies": self._motion_bodies[motion_ids],
             "rg_pos": rg_pos,
             "rb_rot": rb_rot,
@@ -508,8 +521,6 @@ class MotionLibBase():
         return return_dict
     
     def get_motion_state_simple(self, motion_ids, motion_times, offset=None):
-        # import time;print("Called get_motion_state at", time.time())
-
         motion_len = self._motion_lengths[motion_ids]
         num_frames = self._motion_num_frames[motion_ids]
         dt = self._motion_dt[motion_ids]
@@ -518,25 +529,26 @@ class MotionLibBase():
         f0l = frame_idx0 + self.length_starts[motion_ids]
         f1l = frame_idx1 + self.length_starts[motion_ids]
 
+        _d = self._device
+
         if "dof_pos" in self.__dict__:
-            local_rot0 = self.dof_pos[f0l]
-            local_rot1 = self.dof_pos[f1l]
+            local_rot0 = self._fetch(self.dof_pos, f0l)
+            local_rot1 = self._fetch(self.dof_pos, f1l)
         else:
-            local_rot0 = self.lrs[f0l]
-            local_rot1 = self.lrs[f1l]
-            
-        body_vel0 = self.gvs[f0l]
-        body_vel1 = self.gvs[f1l]
+            local_rot0 = self._fetch(self.lrs, f0l)
+            local_rot1 = self._fetch(self.lrs, f1l)
 
-        body_ang_vel0 = self.gavs[f0l]
-        body_ang_vel1 = self.gavs[f1l]
+        body_vel0 = self._fetch(self.gvs, f0l)
+        body_vel1 = self._fetch(self.gvs, f1l)
 
-        # breakpoint()
-        rg_pos0 = self.gts[f0l, :]
-        rg_pos1 = self.gts[f1l, :]
+        body_ang_vel0 = self._fetch(self.gavs, f0l)
+        body_ang_vel1 = self._fetch(self.gavs, f1l)
 
-        dof_vel0 = self.dvs[f0l]
-        dof_vel1 = self.dvs[f1l]
+        rg_pos0 = self._fetch(self.gts, f0l)
+        rg_pos1 = self._fetch(self.gts, f1l)
+
+        dof_vel0 = self._fetch(self.dvs, f0l)
+        dof_vel1 = self._fetch(self.dvs, f1l)
 
         vals = [local_rot0, local_rot1, body_vel0, body_vel1, body_ang_vel0, body_ang_vel1, rg_pos0, rg_pos1, dof_vel0, dof_vel1]
         for v in vals:
@@ -568,8 +580,8 @@ class MotionLibBase():
         return_dict = {}
         
         if "gts_t" in self.__dict__:
-            rg_pos_t0 = self.gts_t[f0l]
-            rg_pos_t1 = self.gts_t[f1l]
+            rg_pos_t0 = self._fetch(self.gts_t, f0l)
+            rg_pos_t1 = self._fetch(self.gts_t, f1l)
             
             # rg_rot_t0 = self.grs_t[f0l]
             # rg_rot_t1 = self.grs_t[f1l]

--- a/tests/test_motion_lib_offload.py
+++ b/tests/test_motion_lib_offload.py
@@ -1,0 +1,229 @@
+"""
+Verify motion library CPU offload produces bit-for-bit identical results
+compared to the default GPU-resident mode.
+
+Requires a CUDA GPU and the g1 robot asset files.
+Run with:
+    PYTHONPATH=/root/CLOT-RL-fork pytest tests/test_motion_lib_offload.py -v
+"""
+
+import copy
+import tempfile
+import os
+
+import numpy as np
+import pytest
+import torch
+import joblib
+from easydict import EasyDict
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA GPU required"
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+ASSET_ROOT = "humanoidverse/data/robots/g1/"
+ASSET_FILE = "g1_23dof_lock_wrist_fitmotionONLY.xml"
+NUM_JOINTS = 24
+NUM_FRAMES = 60
+FPS = 50
+
+
+def _make_synthetic_motion(num_frames: int, num_joints: int, fps: int) -> dict:
+    """Create a minimal synthetic motion clip dict."""
+    rng = np.random.RandomState(42)
+    return {
+        "root_trans_offset": rng.randn(num_frames, 3).astype(np.float64) * 0.1
+        + np.array([0.0, 0.0, 0.8]),
+        "pose_aa": rng.randn(num_frames, num_joints, 3).astype(np.float32) * 0.05,
+        "fps": fps,
+    }
+
+
+def _base_motion_cfg() -> EasyDict:
+    """Return a minimal motion config matching the robot YAML structure."""
+    return EasyDict(
+        {
+            "motion_lib_type": "ZTJ",
+            "motion_file": "PLACEHOLDER",
+            "asset": {
+                "assetRoot": ASSET_ROOT,
+                "assetFileName": ASSET_FILE,
+            },
+            "humanoid_type": "g1_23dof_lock_wrist",
+            "bias_offset": False,
+            "has_self_collision": True,
+            "has_mesh": False,
+            "has_jt_limit": False,
+            "has_dof_subset": True,
+            "has_upright_start": True,
+            "has_smpl_pd_offset": False,
+            "remove_toe": False,
+            "motion_sym_loss": False,
+            "big_ankle": True,
+            "has_shape_obs": False,
+            "has_shape_obs_disc": False,
+            "has_shape_variation": False,
+            "masterfoot": False,
+            "freeze_toe": False,
+            "freeze_hand": False,
+            "box_body": True,
+            "real_weight": True,
+            "real_weight_porpotion_capsules": True,
+            "real_weight_porpotion_boxes": True,
+            "nums_extend_bodies": 3,
+            "extend_config": [
+                {
+                    "joint_name": "left_hand_link",
+                    "parent_name": "left_elbow_link",
+                    "pos": [0.25, 0.0, 0.0],
+                    "rot": [1.0, 0.0, 0.0, 0.0],
+                },
+                {
+                    "joint_name": "right_hand_link",
+                    "parent_name": "right_elbow_link",
+                    "pos": [0.25, 0.0, 0.0],
+                    "rot": [1.0, 0.0, 0.0, 0.0],
+                },
+                {
+                    "joint_name": "head_link",
+                    "parent_name": "torso_link",
+                    "pos": [0.0, 0.0, 0.42],
+                    "rot": [1.0, 0.0, 0.0, 0.0],
+                },
+            ],
+            "body_names": [
+                "pelvis",
+                "left_hip_pitch_link", "left_hip_roll_link", "left_hip_yaw_link",
+                "left_knee_link", "left_ankle_pitch_link", "left_ankle_roll_link",
+                "right_hip_pitch_link", "right_hip_roll_link", "right_hip_yaw_link",
+                "right_knee_link", "right_ankle_pitch_link", "right_ankle_roll_link",
+                "waist_yaw_link", "waist_roll_link", "torso_link",
+                "left_shoulder_pitch_link", "left_shoulder_roll_link",
+                "left_shoulder_yaw_link", "left_elbow_link",
+                "right_shoulder_pitch_link", "right_shoulder_roll_link",
+                "right_shoulder_yaw_link", "right_elbow_link",
+            ],
+            "dof_names": [
+                "left_hip_pitch_link", "left_hip_roll_link", "left_hip_yaw_link",
+                "left_knee_link", "left_ankle_pitch_link", "left_ankle_roll_link",
+                "right_hip_pitch_link", "right_hip_roll_link", "right_hip_yaw_link",
+                "right_knee_link", "right_ankle_pitch_link", "right_ankle_roll_link",
+                "waist_yaw_link", "waist_roll_link", "torso_link",
+                "left_shoulder_pitch_link", "left_shoulder_roll_link",
+                "left_shoulder_yaw_link", "left_elbow_link",
+                "right_shoulder_pitch_link", "right_shoulder_roll_link",
+                "right_shoulder_yaw_link", "right_elbow_link",
+            ],
+            "cpu_offload": False,  # will be overridden per-instance
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def motion_pkl(tmp_path_factory):
+    """Write a synthetic .pkl motion file and return its path."""
+    tmp_dir = tmp_path_factory.mktemp("motions")
+    path = str(tmp_dir / "test_motion.pkl")
+    motion = _make_synthetic_motion(NUM_FRAMES, NUM_JOINTS, FPS)
+    joblib.dump({"clip_0": motion}, path)
+    return path
+
+
+@pytest.fixture(scope="module")
+def lib_pair(motion_pkl):
+    """Create two MotionLibRobotZTJ instances: gpu-only and cpu-offload."""
+    from humanoidverse.utils.motion_lib.motion_lib_robot_ztj import MotionLibRobotZTJ
+
+    device = torch.device("cuda:0")
+    num_envs = 8
+
+    cfg_gpu = _base_motion_cfg()
+    cfg_gpu.motion_file = motion_pkl
+    cfg_gpu.cpu_offload = False
+
+    cfg_off = copy.deepcopy(cfg_gpu)
+    cfg_off.cpu_offload = True
+
+    lib_gpu = MotionLibRobotZTJ(cfg_gpu, num_envs=num_envs, device=device)
+    lib_off = MotionLibRobotZTJ(cfg_off, num_envs=num_envs, device=device)
+    return lib_gpu, lib_off
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_motion_state_identical(lib_pair):
+    """get_motion_state must return bit-for-bit identical dicts."""
+    lib_gpu, lib_off = lib_pair
+    device = lib_gpu._device
+
+    torch.manual_seed(0)
+    motion_ids = lib_gpu.sample_motions(8)
+    motion_times = lib_gpu.sample_time(motion_ids)
+
+    res_gpu = lib_gpu.get_motion_state(motion_ids, motion_times)
+    res_off = lib_off.get_motion_state(motion_ids, motion_times)
+
+    assert set(res_gpu.keys()) == set(res_off.keys()), "Key mismatch"
+    for key in res_gpu:
+        a, b = res_gpu[key], res_off[key]
+        assert a.device == b.device, f"{key}: device mismatch {a.device} vs {b.device}"
+        assert torch.equal(a, b), f"{key}: values differ"
+
+
+def test_get_motion_state_simple_identical(lib_pair):
+    """get_motion_state_simple must return bit-for-bit identical dicts."""
+    lib_gpu, lib_off = lib_pair
+
+    torch.manual_seed(1)
+    motion_ids = lib_gpu.sample_motions(8)
+    motion_times = lib_gpu.sample_time(motion_ids)
+
+    res_gpu = lib_gpu.get_motion_state_simple(motion_ids, motion_times)
+    res_off = lib_off.get_motion_state_simple(motion_ids, motion_times)
+
+    assert set(res_gpu.keys()) == set(res_off.keys()), "Key mismatch"
+    for key in res_gpu:
+        a, b = res_gpu[key], res_off[key]
+        assert torch.equal(a, b), f"{key}: values differ"
+
+
+def test_multiple_random_rounds(lib_pair):
+    """Run several rounds with random motion_ids and times."""
+    lib_gpu, lib_off = lib_pair
+
+    for seed in range(10):
+        torch.manual_seed(seed + 100)
+        motion_ids = lib_gpu.sample_motions(8)
+        motion_times = lib_gpu.sample_time(motion_ids)
+
+        res_gpu = lib_gpu.get_motion_state(motion_ids, motion_times)
+        res_off = lib_off.get_motion_state(motion_ids, motion_times)
+
+        for key in res_gpu:
+            assert torch.equal(res_gpu[key], res_off[key]), (
+                f"Round {seed}, key '{key}': values differ"
+            )
+
+
+def test_gpu_lib_tensors_on_device(lib_pair):
+    """With cpu_offload=False, stored tensors should live on GPU."""
+    lib_gpu, _ = lib_pair
+    for name in ("gts", "grs", "lrs", "gvs", "gavs", "dvs"):
+        t = getattr(lib_gpu, name)
+        assert t.device.type == "cuda", f"{name} should be on cuda, got {t.device}"
+
+
+def test_offload_lib_tensors_on_cpu(lib_pair):
+    """With cpu_offload=True, stored tensors should be on CPU (pinned)."""
+    _, lib_off = lib_pair
+    for name in ("gts", "grs", "lrs", "gvs", "gavs", "dvs"):
+        t = getattr(lib_off, name)
+        assert t.device.type == "cpu", f"{name} should be on cpu, got {t.device}"
+        assert t.is_pinned(), f"{name} should be pinned memory"


### PR DESCRIPTION
Background
----------
Motion library (MotionLibRobotZTJ) stores large pre-computed tensors (global translations, rotations, velocities, etc.) on GPU. For the g1 robot with ~50 fps motion data, this consumes ~7.7 GB VRAM per GPU, severely limiting the number of parallel environments — on RTX 4090 (24 GB) only ~1024 envs fit.

Implementation
--------------
Add a `cpu_offload` config flag (default: false) that, when enabled:

1. Stores all motion tensors in CPU pinned memory instead of GPU VRAM via `_store_tensor()` helper — 16 tensor fields in `load_motions()` now route through this method.

2. On-demand transfers indexed slices to GPU in `get_motion_state()` and `get_motion_state_simple()` via `_fetch()` helper — replaces all direct `tensor[idx]` with `tensor[idx.cpu()].to(device)` when offloading is active.

3. Config entry added to g1_23dof_lock_wrist.yaml: robot.motion.cpu_offload: false Can be overridden at launch: `robot.motion.cpu_offload=true`

4. Bugfix: directory-mode motion loading now saves the file list before numpy conversion to avoid indexing a numpy array with `joblib.load()`.

Benefits
--------
- Frees ~7.7 GB GPU VRAM per card, allowing num_envs to scale from 1024 → 2304+ on RTX 4090 (24 GB) — a 2.25x throughput improvement.
- Default off: zero behavior change for existing users.
- Bit-for-bit identical outputs between offload and non-offload modes.

Testing
-------
- Unit tests (tests/test_motion_lib_offload.py): 5 pytest cases verify bit-for-bit consistency between cpu_offload=true and false modes, tensor placement (GPU vs CPU pinned), and multi-round random sampling. All 5/5 passed.
- 8-GPU training (RTX 4090 x8):
  * cpu_offload=false, num_envs=1024, 50 iters: PASSED (exit_code=0)
  * cpu_offload=true,  num_envs=2304, 50 iters: PASSED (exit_code=0)
- Verified on both CLOT-fork and original CLOT repos.